### PR TITLE
Fixed Legacy Material ID Error for Cooldowns

### DIFF
--- a/src/main/java/com/lunarclient/bukkitapi/cooldown/LCCooldown.java
+++ b/src/main/java/com/lunarclient/bukkitapi/cooldown/LCCooldown.java
@@ -7,6 +7,8 @@ import lombok.Data;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Data
@@ -14,24 +16,38 @@ public class LCCooldown implements LCPacketWrapper<LCPacketCooldown> {
 
     private final String name;
     private final long millis;
-    private final Material itemId;
+    private Material item;
+    private final int itemId;
     // The packet that will be sent to the Lunar Client player
     // Because of @Data, we don't need a getter.
     private final LCPacketCooldown packet;
+
 
     /**
      * Used to create a persisting cooldown that can be sent to many players.
      *
      * @param name A unique name that is not null
      * @param millis The duration for the cooldown in milliseconds, that is greater (or equal to reset) to 0.
-     * @param itemId The icon that will be displayed in Lunar Client.
+     * @param itemId The ID of the material that will be the icon
      */
-    public LCCooldown(String name, long millis, Material itemId) {
+    public LCCooldown(String name, long millis, int itemId) {
         Preconditions.checkArgument(millis > 0, "Cooldown must have a valid time > 0.");
         this.name = Preconditions.checkNotNull(name, "Cooldown Name cannot be null.");
         this.millis = millis;
-        this.itemId = Preconditions.checkNotNull(itemId, "Cooldown Icon cannot be null.");
-        packet = new LCPacketCooldown(name, millis, itemId.getId());
+        this.item = Material.values()[itemId];
+        this.itemId = itemId;
+        packet = new LCPacketCooldown(name, millis, itemId);
+    }
+
+    /**
+     * Used to create a persisting cooldown that can be sent to many players.
+     *
+     * @param name A unique name that is not null
+     * @param millis The duration for the cooldown in milliseconds, that is greater (or equal to reset) to 0.
+     * @param item The icon that will be displayed in Lunar Client.
+     */
+    public LCCooldown(String name, long millis, Material item) {
+        this(name, millis, convertMaterialToId(item));
     }
 
     /**
@@ -64,6 +80,17 @@ public class LCCooldown implements LCPacketWrapper<LCPacketCooldown> {
      * @param player The player to clear the cooldown for.
      */
     public void clear(Player player) {
-        send(player, new LCPacketCooldown(name, 0, itemId.getId()));
+        send(player, new LCPacketCooldown(name, 0, itemId));
+    }
+
+    /**
+     * Converts a Material into a Lunar usable ID.
+     *
+     * @param material The material to convert.
+     * @return The ID of the material.
+     */
+    public static int convertMaterialToId(Material material) {
+        List<Material> materialList = Arrays.asList(Material.values());
+        return materialList.indexOf(material);
     }
 }


### PR DESCRIPTION
# Description

Fixes the `Cannot get ID of Modern Material` error.

## Fixed Issues

 - #7 

# Changes

- Changed type of itemId to Integer
- Added Item used as a replacement for the itemId Material
- Created new constructor for taking an Integer instead of a Material
- Created Material conversion method
  - `LCCooldown#convertMaterialToId(Material)`

## Potential issues

- Outdated client versions may display the wrong material
- Developers accessing `LCCooldown#getItemId()` will need to change to `LCCooldown#getItem()`
